### PR TITLE
[feat] HAN-79 User GET 프로필 수정에 필요한 정보 불러오기

### DIFF
--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -1,92 +1,10 @@
 import statusCode from '../modules/statusCode';
-import util from "../modules/util";
-import message  from "../modules/responseMessage";
-
-
-import { UserCreateDto } from "../interfaces/user/UserCreateDto";
-import { UserUpdateDto } from "../interfaces/user/UserUpdateDto";
-import { UserResponseDto } from '../interfaces/user/UserResponseDto';
-import { PostBaseResponseDto } from "../interfaces/common/PostBaseResponseDto";
 import { UserService } from "../services";
 
 
 import { Request, Response } from "express";
 import { UserInfoDto } from '../interfaces/user/UserInfoDto';
 
-
-const createUser = async (req: Request, res: Response): Promise<void> => {
-    const userCreateDto: UserCreateDto = req.body;
-
-    try {
-        const data: PostBaseResponseDto = await UserService.createUser(userCreateDto);
-
-        res.status(statusCode.CREATED).send(data);
-
-    }
-    catch (error) {
-        console.log(error);
-        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail());
-    }
-}
-
-const updateUser = async (req: Request, res: Response): Promise<void> => {
-    const userUpdateDto: UserUpdateDto = req.body;
-    const { userId } = req.params;
-
-    try {
-        await UserService.updateUser(userId, userUpdateDto);
-        res.status(statusCode.NO_CONTENT).send(util.success());
-
-    }
-    catch (error) {
-        console.log(error);
-        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail());
-    }
-}
-
-const findUserById = async (req: Request, res: Response): Promise<void> => {
-    const { userId } = req.params;
-
-    try {
-        const data: UserResponseDto | null = await UserService.findUserById(userId);
-
-        res.status(statusCode.OK).send(util.success(data));
-
-    }
-    catch (error) {
-        console.log(error);
-        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail());
-    }
-}
-
-const findUserList = async (res: Response): Promise<void> => {
-    try {
-        const data: UserResponseDto[] | null = await UserService.findUserList();
-
-        res.status(statusCode.OK).send(util.success(data));
-
-    }
-    catch (error) {
-        console.log(error);
-        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail());
-    }
-}
-
-const findUserByKakao = async (req: Request, res: Response): Promise<void> => {
-    const { kakaoId } = req.params;
-
-    try {
-        const data: UserResponseDto | null = await UserService.findUserByKakao(kakaoId);
-        
-        res.status(statusCode.OK).send(util.success(data));
-
-    } catch (error)
-    {
-        console.log(error);
-        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail());
-    }
-
-}
 
 const getUserForProfileUpdate = async (req: Request, res: Response): Promise<void> => {
 
@@ -105,28 +23,7 @@ const getUserForProfileUpdate = async (req: Request, res: Response): Promise<voi
 
 }
 
-const deleteUser = async (req: Request, res: Response): Promise<void> => {
-    const { userId } = req.params;
-
-    try {
-        await UserService.deleteUser(userId);
-
-        res.status(statusCode.NO_CONTENT).send(statusCode.OK);
-
-    }
-    catch (error) {
-        console.log(error);
-        res.status(statusCode.INTERNAL_SERVER_ERROR).send(statusCode.INTERNAL_SERVER_ERROR);
-    }
-}
-
 
 export default {
-    createUser,
-    updateUser,
-    findUserById,
-    findUserList,
-    deleteUser,
-    findUserByKakao,
     getUserForProfileUpdate
 }

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -1,0 +1,132 @@
+import statusCode from '../modules/statusCode';
+import util from "../modules/util";
+import message  from "../modules/responseMessage";
+
+
+import { UserCreateDto } from "../interfaces/user/UserCreateDto";
+import { UserUpdateDto } from "../interfaces/user/UserUpdateDto";
+import { UserResponseDto } from '../interfaces/user/UserResponseDto';
+import { PostBaseResponseDto } from "../interfaces/common/PostBaseResponseDto";
+import { UserService } from "../services";
+
+
+import { Request, Response } from "express";
+import { UserInfoDto } from '../interfaces/user/UserInfoDto';
+
+
+const createUser = async (req: Request, res: Response): Promise<void> => {
+    const userCreateDto: UserCreateDto = req.body;
+
+    try {
+        const data: PostBaseResponseDto = await UserService.createUser(userCreateDto);
+
+        res.status(statusCode.CREATED).send(data);
+
+    }
+    catch (error) {
+        console.log(error);
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail());
+    }
+}
+
+const updateUser = async (req: Request, res: Response): Promise<void> => {
+    const userUpdateDto: UserUpdateDto = req.body;
+    const { userId } = req.params;
+
+    try {
+        await UserService.updateUser(userId, userUpdateDto);
+        res.status(statusCode.NO_CONTENT).send(util.success());
+
+    }
+    catch (error) {
+        console.log(error);
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail());
+    }
+}
+
+const findUserById = async (req: Request, res: Response): Promise<void> => {
+    const { userId } = req.params;
+
+    try {
+        const data: UserResponseDto | null = await UserService.findUserById(userId);
+
+        res.status(statusCode.OK).send(util.success(data));
+
+    }
+    catch (error) {
+        console.log(error);
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail());
+    }
+}
+
+const findUserList = async (res: Response): Promise<void> => {
+    try {
+        const data: UserResponseDto[] | null = await UserService.findUserList();
+
+        res.status(statusCode.OK).send(util.success(data));
+
+    }
+    catch (error) {
+        console.log(error);
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail());
+    }
+}
+
+const findUserByKakao = async (req: Request, res: Response): Promise<void> => {
+    const { kakaoId } = req.params;
+
+    try {
+        const data: UserResponseDto | null = await UserService.findUserByKakao(kakaoId);
+        
+        res.status(statusCode.OK).send(util.success(data));
+
+    } catch (error)
+    {
+        console.log(error);
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail());
+    }
+
+}
+
+const getUserForProfileUpdate = async (req: Request, res: Response): Promise<void> => {
+
+    const { userId } = req.params;
+
+    try {
+        const data: UserInfoDto | null = await UserService.getUserForProfileUpdate(userId);
+
+        res.status(statusCode.OK).send(data);
+    }
+
+    catch (error) {
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(statusCode.INTERNAL_SERVER_ERROR);
+    }
+    
+
+}
+
+const deleteUser = async (req: Request, res: Response): Promise<void> => {
+    const { userId } = req.params;
+
+    try {
+        await UserService.deleteUser(userId);
+
+        res.status(statusCode.NO_CONTENT).send(statusCode.OK);
+
+    }
+    catch (error) {
+        console.log(error);
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(statusCode.INTERNAL_SERVER_ERROR);
+    }
+}
+
+
+export default {
+    createUser,
+    updateUser,
+    findUserById,
+    findUserList,
+    deleteUser,
+    findUserByKakao,
+    getUserForProfileUpdate
+}

--- a/src/interfaces/user/UserCreateDto.ts
+++ b/src/interfaces/user/UserCreateDto.ts
@@ -1,0 +1,10 @@
+export interface UserCreateDto {
+    name: String;
+    introduction?: String;
+    mannerTemperature: Number;
+    hashtags?: [String];
+    isLogOut: Boolean;
+    kakaoId: Number;
+    kakaoToken: String;
+    fcmToken: String;
+}

--- a/src/interfaces/user/UserInfo.ts
+++ b/src/interfaces/user/UserInfo.ts
@@ -1,0 +1,12 @@
+
+
+export interface UserInfo {
+    name: String;
+    introduction: String;
+    mannerTemperature: Number;
+    hashtags: [String];
+    isLogOut: Boolean;
+    kakaoId: Number;
+    kakaoToken: String;
+    fcmToken: String;
+}

--- a/src/interfaces/user/UserInfoDto.ts
+++ b/src/interfaces/user/UserInfoDto.ts
@@ -1,0 +1,6 @@
+
+export interface UserInfoDto {
+    name: String;
+    introduction: String;
+    hashtags: [String];
+}

--- a/src/interfaces/user/UserResponseDto.ts
+++ b/src/interfaces/user/UserResponseDto.ts
@@ -1,0 +1,6 @@
+import mongoose from "mongoose";
+import { UserCreateDto } from "./UserCreateDto";
+
+export interface UserResponseDto extends UserCreateDto {
+    _id: mongoose.Schema.Types.ObjectId;
+}

--- a/src/interfaces/user/UserUpdateDto.ts
+++ b/src/interfaces/user/UserUpdateDto.ts
@@ -1,0 +1,10 @@
+export interface UserUpdateDto {
+    name?: String;
+    introduction?: String;
+    mannerTemperature?: Number;
+    hashtags?: [String];
+    isLogout?: Boolean;
+    kakaoId?: Number;
+    kakaoToken?: String;
+    fcmToken?: String;
+}

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -5,7 +5,7 @@ import { UserInfo } from "../interfaces/user/UserInfo";
 const UserSchema = new mongoose.Schema( {
     name: {
         type: String,
-        required: true
+        default: ''
     },
     introduction: {
         type: String,

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,0 +1,41 @@
+import mongoose from "mongoose";
+import { UserInfo } from "../interfaces/user/UserInfo";
+
+
+const UserSchema = new mongoose.Schema( {
+    name: {
+        type: String,
+        required: true
+    },
+    introduction: {
+        type: String,
+        default: ''
+    },
+    mannerTemperature: {
+        type: Number,
+        required: true,
+        default: 36.5
+    },
+    hashtags: {
+        type: [String],
+        default: []
+    },
+    isLogout: {
+        type: Boolean,
+        default: true
+    },
+    kakaoId: {
+        type: Number
+    },
+    kakaoToken: {
+        type: String
+    },
+    fcmToken: {
+        type: String
+    }
+
+});
+
+
+
+export default mongoose.model<UserInfo & mongoose.Document>("User", UserSchema);

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { UserController } from "../controllers";
+
+const router: Router = Router();
+
+router.post('/', UserController.createUser);
+router.put('/:userId', UserController.updateUser);
+router.get('/:userId', UserController.findUserById);
+router.get('/', UserController.findUserList);
+router.delete('/:userId', UserController.deleteUser);
+router.get('/profile/:userId', UserController.getUserForProfileUpdate);
+
+export default router;

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -3,11 +3,6 @@ import { UserController } from "../controllers";
 
 const router: Router = Router();
 
-router.post('/', UserController.createUser);
-router.put('/:userId', UserController.updateUser);
-router.get('/:userId', UserController.findUserById);
-router.get('/', UserController.findUserList);
-router.delete('/:userId', UserController.deleteUser);
 router.get('/profile/:userId', UserController.getUserForProfileUpdate);
 
 export default router;

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,94 +1,7 @@
-import { UserCreateDto } from '../interfaces/user/UserCreateDto';
-import { UserUpdateDto } from '../interfaces/user/UserUpdateDto';
-import { UserResponseDto } from '../interfaces/user/UserResponseDto';
+
 import { UserInfoDto } from '../interfaces/user/UserInfoDto';
 import User from '../models/User';
 
-
-const createUser = async (userCreateDto: UserCreateDto) => {
-    try {
-        const user = new User({
-            name: userCreateDto.name,
-            introduction: userCreateDto.introduction,
-            mannerTemperature: userCreateDto.mannerTemperature,
-            hashtags: userCreateDto.hashtags,
-            kakaoId: userCreateDto.kakaoId,
-            kakaoToken: userCreateDto.kakaoToken,
-            fcmToken: userCreateDto.fcmToken
-        });
-
-        await user.save();
-        const data = {
-            _id: user._id
-        };
-
-        return data;
-    } catch (error)
-    {
-        console.log(error);
-        throw(error);
-    };
-}
-
-const updateUser = async (userId: string, userUpdateDto: UserUpdateDto) => {
-    try {
-        const updatedUser = {
-            name: userUpdateDto.name,
-            introduction: userUpdateDto.introduction,
-            mannerTemperature: userUpdateDto.mannerTemperature,
-            hashtags: userUpdateDto.hashtags,
-            isLogout: userUpdateDto.isLogout,
-            kakaoId: userUpdateDto.kakaoId,
-            kakaoToken: userUpdateDto.kakaoToken,
-            fcmToken: userUpdateDto.fcmToken
-        }
-
-        await User.findByIdAndUpdate(userId, updatedUser);
-
-    } catch (error)
-    {
-        console.log(error);
-        throw(error);
-    };
-}
-
-const findUserById = async (userId: string) => {
-    try {
-        const user: UserResponseDto | null = await User.findById(userId);
-
-        return user;
-    } catch (error)
-    {
-        console.log(error);
-        throw(error);
-    };
-}
-
-
-const findUserList = async () => {
-    try {
-        const users: UserResponseDto[] | null = await User.find();
-
-        return users;
-    } catch (error)
-    {
-        console.log(error);
-        throw(error);
-    };
-}
-
-const findUserByKakao = async (userId: any) => {
-    try {
-        const user: UserResponseDto | null = await User.findOne({kakaoId: userId});
-
-        return user;
-    } catch (error)
-    {
-        console.log(error);
-        throw(error);
-    }
-
-};
 
 const getUserForProfileUpdate = async (userId: any) => {
 
@@ -106,24 +19,6 @@ const getUserForProfileUpdate = async (userId: any) => {
 
 }
 
-const deleteUser = async (userId: string) => {
-    try {
-        await User.findByIdAndDelete(userId);
-    } catch (error) {
-        console.log(error);
-        throw (error);
-    };
-};
-
-
-
-
 export default {
-    createUser,
-    updateUser,
-    findUserById,
-    findUserList,
-    deleteUser,
-    findUserByKakao,
     getUserForProfileUpdate
 }

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,0 +1,129 @@
+import { UserCreateDto } from '../interfaces/user/UserCreateDto';
+import { UserUpdateDto } from '../interfaces/user/UserUpdateDto';
+import { UserResponseDto } from '../interfaces/user/UserResponseDto';
+import { UserInfoDto } from '../interfaces/user/UserInfoDto';
+import User from '../models/User';
+
+
+const createUser = async (userCreateDto: UserCreateDto) => {
+    try {
+        const user = new User({
+            name: userCreateDto.name,
+            introduction: userCreateDto.introduction,
+            mannerTemperature: userCreateDto.mannerTemperature,
+            hashtags: userCreateDto.hashtags,
+            kakaoId: userCreateDto.kakaoId,
+            kakaoToken: userCreateDto.kakaoToken,
+            fcmToken: userCreateDto.fcmToken
+        });
+
+        await user.save();
+        const data = {
+            _id: user._id
+        };
+
+        return data;
+    } catch (error)
+    {
+        console.log(error);
+        throw(error);
+    };
+}
+
+const updateUser = async (userId: string, userUpdateDto: UserUpdateDto) => {
+    try {
+        const updatedUser = {
+            name: userUpdateDto.name,
+            introduction: userUpdateDto.introduction,
+            mannerTemperature: userUpdateDto.mannerTemperature,
+            hashtags: userUpdateDto.hashtags,
+            isLogout: userUpdateDto.isLogout,
+            kakaoId: userUpdateDto.kakaoId,
+            kakaoToken: userUpdateDto.kakaoToken,
+            fcmToken: userUpdateDto.fcmToken
+        }
+
+        await User.findByIdAndUpdate(userId, updatedUser);
+
+    } catch (error)
+    {
+        console.log(error);
+        throw(error);
+    };
+}
+
+const findUserById = async (userId: string) => {
+    try {
+        const user: UserResponseDto | null = await User.findById(userId);
+
+        return user;
+    } catch (error)
+    {
+        console.log(error);
+        throw(error);
+    };
+}
+
+
+const findUserList = async () => {
+    try {
+        const users: UserResponseDto[] | null = await User.find();
+
+        return users;
+    } catch (error)
+    {
+        console.log(error);
+        throw(error);
+    };
+}
+
+const findUserByKakao = async (userId: any) => {
+    try {
+        const user: UserResponseDto | null = await User.findOne({kakaoId: userId});
+
+        return user;
+    } catch (error)
+    {
+        console.log(error);
+        throw(error);
+    }
+
+};
+
+const getUserForProfileUpdate = async (userId: any) => {
+
+    try {
+        const data: UserInfoDto | null = await User.findById(userId);
+
+        return data;
+    }
+
+    catch (error) {
+        console.log(error);
+        throw (error);
+    }
+    
+
+}
+
+const deleteUser = async (userId: string) => {
+    try {
+        await User.findByIdAndDelete(userId);
+    } catch (error) {
+        console.log(error);
+        throw (error);
+    };
+};
+
+
+
+
+export default {
+    createUser,
+    updateUser,
+    findUserById,
+    findUserList,
+    deleteUser,
+    findUserByKakao,
+    getUserForProfileUpdate
+}


### PR DESCRIPTION
프로필 수정에 필요한 정보 (닉네임, 해쉬태그 리스트, 자기소개)만 GET으로 불러오는 기능입니다.

## 관련 이슈 번호 🔎

- [HAN-79](https://koreatech-hanbun.atlassian.net/browse/HAN-79?atlOrigin=eyJpIjoiMjI3OTM3NjQ4ZWM0NGVjZGFmYzQ0NDgyN2YwNWRkNTciLCJwIjoiaiJ9)

<br>

## 주요 변경 사항 🔑

- 프로필 수정에 필요한 정보 (닉네임, 해쉬태그 리스트, 자기소개)만 Get으로 불러오는 기능입니다. 프로필 뷰에서 유저 정보를 Put하기 전 이용하는 것을 상정하고 작성했습니다.

<br>

## 하고싶은 말 📢

- service, controller, router의 getUserForProfileUpdate 부분만 확인해주시면 되겠습니다.

<br>

## 관련 스크린샷 (선택) 📷

-

<br>

## 참고자료 📚

-

<br>


[HAN-79]: https://koreatech-hanbun.atlassian.net/browse/HAN-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ