### PR TITLE
[fix] DELETE API 수정.

### DIFF
--- a/src/controllers/chat/ChatController.ts
+++ b/src/controllers/chat/ChatController.ts
@@ -3,7 +3,6 @@ import {Request, Response} from 'express';
 import ChatService from '../../services/chat/ChatService';
 import errorGenerator from '../../errors/errorGenerator';
 import message from '../../modules/message';
-import chattingHandler from '../../modules/chattingHandler';
 
 const getChatRooms = async (req: Request, res: Response): Promise<void> => {
   const userId = req.body['userId'];
@@ -18,7 +17,7 @@ const getChatRooms = async (req: Request, res: Response): Promise<void> => {
   try {
     const data = await ChatService.getChatRooms(userId);
 
-    res.status(statusCode.OK).json({data: data});
+    res.status(statusCode.OK).json(data);
   } catch (error: any) {
     if (error.statusCode == statusCode.NOT_FOUND) {
       //찾을 수 없는 정보가 있었다면 NOT FOUND 발송.

--- a/src/controllers/thunder/ThunderController.ts
+++ b/src/controllers/thunder/ThunderController.ts
@@ -75,7 +75,7 @@ const findThunderByHashtag = async (
 ): Promise<void | Response> => {
   const errors: Result<ValidationError> = validationResult(req);
   if (!errors.isEmpty()) {
-    return res.status(statusCode.BAD_REQUEST).send(message.BAD_REQUEST);
+    return res.status(statusCode.BAD_REQUEST).send(statusCode.BAD_REQUEST);
   }
 
   const userId: string = req.body['userId'];
@@ -111,7 +111,7 @@ const findThunder = async (
 
     res.status(statusCode.OK).send(data);
   } catch (error: any) {
-    if (error.msg == message.NOT_FOUND_ROOM) {
+    if (error.statusCode == statusCode.NOT_FOUND) {
       console.log(error);
       res.status(statusCode.NOT_FOUND).send(statusCode.NOT_FOUND);
     } else {
@@ -134,7 +134,7 @@ const updateThunder = async (
 ): Promise<void | Response> => {
   const errors: Result<ValidationError> = validationResult(req);
   if (!errors.isEmpty()) {
-    return res.status(statusCode.BAD_REQUEST).send(message.BAD_REQUEST);
+    return res.status(statusCode.BAD_REQUEST).send(statusCode.BAD_REQUEST);
   }
 
   const thunderUpdateDto: ThunderUpdateDto = req.body;
@@ -146,10 +146,10 @@ const updateThunder = async (
 
     res.status(statusCode.OK).send(statusCode.OK);
   } catch (error: any) {
-    if (error.msg == message.NOT_FOUND_ROOM) {
+    if (error.statusCode == statusCode.NOT_FOUND) {
       console.log(error);
       res.status(statusCode.NOT_FOUND).send(statusCode.NOT_FOUND);
-    } else if (error.msg == message.FORBIDDEN) {
+    } else if (error.statusCode == statusCode.FORBIDDEN) {
       console.log(error);
       res.status(statusCode.FORBIDDEN).send(statusCode.FORBIDDEN);
     } else {
@@ -172,7 +172,7 @@ const joinThunder = async (
 ): Promise<void | Response> => {
   const errors: Result<ValidationError> = validationResult(req);
   if (!errors.isEmpty()) {
-    return res.status(statusCode.BAD_REQUEST).send(message.BAD_REQUEST);
+    return res.status(statusCode.BAD_REQUEST).send(statusCode.BAD_REQUEST);
   }
 
   const userId: string = req.body['userId'];
@@ -183,10 +183,10 @@ const joinThunder = async (
 
     res.status(statusCode.OK).send(statusCode.OK);
   } catch (error: any) {
-    if (error.msg == message.NOT_FOUND_ROOM) {
+    if (error.statusCode == statusCode.NOT_FOUND) {
       console.log(error);
       res.status(statusCode.NOT_FOUND).send(statusCode.NOT_FOUND);
-    } else if (error.msg == message.FORBIDDEN) {
+    } else if (error.statusCode == statusCode.FORBIDDEN) {
       console.log(error);
       res.status(statusCode.FORBIDDEN).send(statusCode.FORBIDDEN);
     } else {
@@ -209,7 +209,7 @@ const outThunder = async (
 ): Promise<void | Response> => {
   const errors: Result<ValidationError> = validationResult(req);
   if (!errors.isEmpty()) {
-    return res.status(statusCode.BAD_REQUEST).send(message.BAD_REQUEST);
+    return res.status(statusCode.BAD_REQUEST).send(statusCode.BAD_REQUEST);
   }
 
   const userId: string = req.body['userId'];
@@ -220,10 +220,10 @@ const outThunder = async (
 
     res.status(statusCode.OK).send(statusCode.OK);
   } catch (error: any) {
-    if (error.msg == message.NOT_FOUND_ROOM) {
+    if (error.statusCode == statusCode.NOT_FOUND) {
       console.log(error);
       res.status(statusCode.NOT_FOUND).send(statusCode.NOT_FOUND);
-    } else if (error.msg == message.FORBIDDEN) {
+    } else if (error.statusCode == statusCode.FORBIDDEN) {
       console.log(error);
       res.status(statusCode.FORBIDDEN).send(statusCode.FORBIDDEN);
     } else {

--- a/src/controllers/user/UserController.ts
+++ b/src/controllers/user/UserController.ts
@@ -11,7 +11,6 @@ import {UserHashtagResponseDto} from '../../interfaces/user/UserHashtagResponseD
 import {UserThunderRecordResponseDto} from '../../interfaces/user/UserThunderRecordResponseDto';
 import {UserAlarmStateResponseDto} from '../../interfaces/user/UserAlarmStateResponseDto';
 
-
 /**
  *
  * @route PUT / user
@@ -124,7 +123,9 @@ const findUserById = async (req: Request, res: Response): Promise<void> => {
     res.status(statusCode.OK).send(util.success(data));
   } catch (error) {
     console.log(error);
-    res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail());
+    res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(statusCode.INTERNAL_SERVER_ERROR);
   }
 };
 
@@ -138,7 +139,9 @@ const findUserByKakao = async (req: Request, res: Response): Promise<void> => {
     res.status(statusCode.OK).send(util.success(data));
   } catch (error) {
     console.log(error);
-    res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail());
+    res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(statusCode.INTERNAL_SERVER_ERROR);
   }
 };
 
@@ -153,6 +156,8 @@ const deleteUser = async (req: Request, res: Response): Promise<void> => {
     console.log(error);
     if (error.statusCode == statusCode.NOT_FOUND) {
       res.status(statusCode.NOT_FOUND).send(statusCode.NOT_FOUND);
+    } else if (error.statusCode.FORBIDDEN) {
+      res.status(statusCode.FORBIDDEN).send(statusCode.FORBIDDEN);
     } else {
       res
         .status(statusCode.INTERNAL_SERVER_ERROR)

--- a/src/interfaces/chat/PersonalChatRoomInfo.ts
+++ b/src/interfaces/chat/PersonalChatRoomInfo.ts
@@ -1,6 +1,5 @@
 import mongoose from 'mongoose';
 export interface PersonalChatRoomInfo {
-  id: String;
   userId: mongoose.Schema.Types.ObjectId;
   enterAt: Date;
   isAlarm: Boolean;

--- a/src/interfaces/thunder/ThunderMembersDto.ts
+++ b/src/interfaces/thunder/ThunderMembersDto.ts
@@ -1,5 +1,8 @@
+import mongoose from 'mongoose';
+
 export interface ThunderMembersDto {
   name: String;
+  userId: mongoose.Types.ObjectId;
   introduction: String;
   hashtags: [String];
   mannerTemperature: Number;

--- a/src/interfaces/user/UserThunderRecordResponseDto.ts
+++ b/src/interfaces/user/UserThunderRecordResponseDto.ts
@@ -3,5 +3,6 @@ import mongoose from 'mongoose';
 export interface UserThunderRecordResponseDto {
   thunderId: mongoose.Types.ObjectId;
   title: string;
+  hashtags: string[];
   deadline: string;
 }

--- a/src/loaders/db.ts
+++ b/src/loaders/db.ts
@@ -6,7 +6,6 @@ import errorGenerator from '../errors/errorGenerator';
 import statusCode from '../modules/statusCode';
 import message from '../modules/message';
 import {pushMessageTemplate} from '../modules/pushMessageTemplate';
-import chattingHandler from '../modules/chattingHandler';
 import User from '../models/User';
 
 const connectDB = async () => {
@@ -50,7 +49,7 @@ const connectDB = async () => {
         token: user[i].fcmToken as string,
       };
 
-      firebase
+      /*firebase
         .messaging()
         .send(alarm)
         .then(function (res: any) {
@@ -62,7 +61,7 @@ const connectDB = async () => {
             msg: message.FCM_ERROR,
             statusCode: statusCode.INTERNAL_SERVER_ERROR,
           });
-        });
+        });*/
     }
   } catch (err: any) {
     console.error(err.message);

--- a/src/models/Thunder.ts
+++ b/src/models/Thunder.ts
@@ -43,12 +43,12 @@ const ThunderSchema = new mongoose.Schema({
   createdAt: {
     type: Date,
     required: false,
-    defalut: Date.now,
+    defalut: Date.now() + 3600000 * 9,
   },
   updatedAt: {
     type: Date,
     required: false,
-    defalut: Date.now,
+    defalut: Date.now() + 3600000 * 9,
   },
 });
 

--- a/src/modules/chattingHandler.ts
+++ b/src/modules/chattingHandler.ts
@@ -38,7 +38,7 @@ const getThunders = async (userId: string): Promise<ThunderInfo[] | null> => {
 
     const result: ThunderInfo[] = await Thunder.find({
       _id: {$in: thunderList}, // 유저 정보의 thunderRecords 안의 정보 중에서
-      deadline: {$gt: new Date()}, // deadline이 아직 안 지난 것만 쿼리. new Date()는 현재 날짜시간
+      deadline: {$gt: new Date().getTime() + 3600000 * 9}, // deadline이 아직 안 지난 것만 쿼리. new Date()는 현재 날짜시간
     });
 
     if (!result) {

--- a/src/modules/message.ts
+++ b/src/modules/message.ts
@@ -30,6 +30,10 @@ const message = {
   DELETE_USER_SUCCESS: '사용자 탈퇴 성공입니다.',
   USER_ALREADY_LOGOUT: '로그아웃한 유저입니다.',
   USER_CREATION_ERROR: '유저 생성 오류입니다.',
+  USER_DELETION_FAIL: '유저 삭제 오류입니다.',
+  USER_CANNOT_DELETE:
+    '사용자 명의로 만들어진 번개가 있으면 탈퇴할 수 없습니다.',
+  USER_ALREADY_IN: '이미 해당 번개에 가입해 있는 유저입니다.',
 
   //thunder
   NOT_FOUND_ROOM: '존재하지 않는 방입니다.',
@@ -45,11 +49,9 @@ const message = {
   FCM_ERROR: 'FCM 메시지 오류',
   KAKAO_SERVER_ERROR: '카카오 서버에서 값을 받아오지 못했습니다.',
 
-
   //chat
   NOT_FOUND_MEMBER: '채팅방 정보를 찾을 수 없습니다.',
   NOT_FOUND_CHAT: '해당 채팅을 찾을 수 없습니다.',
-
 };
 
 export default message;

--- a/src/routes/ThunderRouter.ts
+++ b/src/routes/ThunderRouter.ts
@@ -6,15 +6,14 @@ import auth from '../middlewares/auth';
 
 const router: Router = Router();
 
-router.post('/', auth.auth, ThunderController.createThunder);
-router.get('/', auth.auth, ThunderController.findThunderAll);
 router.get(
   '/hashtags',
   auth.auth,
   [query('hashtag').isString().trim()],
   ThunderController.findThunderByHashtag,
 );
-
+router.post('/', auth.auth, ThunderController.createThunder);
+router.get('/', auth.auth, ThunderController.findThunderAll);
 router.get('/:thunderId', auth.auth, ThunderController.findThunder);
 router.put('/:thunderId', auth.auth, ThunderController.updateThunder);
 router.put('/join/:thunderId', auth.auth, ThunderController.joinThunder);

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -11,6 +11,5 @@ router.get('/alarm', auth.auth, UserController.findUserAlarmState);
 router.put('/', auth.auth, UserController.updateUser);
 router.get('/', auth.auth, UserController.findUserById);
 router.delete('/', auth.auth, UserController.deleteUser);
-router.get('/profile', auth.auth, UserController.getUserForProfileUpdate);
 
 export default router;

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -8,6 +8,7 @@ import statusCode from '../../modules/statusCode';
 import tokenStatus from '../../modules/tokenStatus';
 import {AuthResponseDto} from '../../interfaces/auth/AuthResponseDto';
 import message from '../../modules/message';
+import Thunder from '../../models/Thunder';
 
 const login = async (kakaoToken: string, fcmToken: string) => {
   try {
@@ -179,9 +180,8 @@ const logout = async (userId: string) => {
         isLogOut: true,
         fcmToken: 'NoToken',
       },
-      userId
-    ); 
-    
+      userId,
+    );
   } catch (error) {
     console.log(error);
     throw error;

--- a/src/services/thunder/ThunderService.ts
+++ b/src/services/thunder/ThunderService.ts
@@ -341,8 +341,15 @@ const joinThunder = async (
         $push: {members: myJoinInfo._id},
       });
 
+      const newRecord = new ThunderRecord({
+        thunderId: thunderId,
+        isEvaluate: false,
+      });
+
+      await newRecord.save();
+
       await User.findByIdAndUpdate(userId, {
-        $push: {thunderRecords: thunderId},
+        $push: {thunderRecords: newRecord._id},
       });
     } else {
       throw errorGenerator({
@@ -383,9 +390,16 @@ const outThunder = async (userId: string, thunderId: string): Promise<void> => {
 
       await PersonalChatRoom.findByIdAndDelete(myInfo._id);
 
-      await User.findByIdAndUpdate(userId, {
-        $pull: {thunderRecords: thunderId},
+      const record = await ThunderRecord.findByIdAndDelete({
+        thunderId: thunderId,
+        userId: userId,
       });
+
+      await User.findByIdAndUpdate(userId, {
+        $pull: {thunderRecords: record._id},
+      });
+
+      await ThunderRecord.findByIdAndDelete(record._id);
     } else {
       throw errorGenerator({
         msg: message.FORBIDDEN,

--- a/src/services/thunder/ThunderService.ts
+++ b/src/services/thunder/ThunderService.ts
@@ -344,6 +344,8 @@ const outThunder = async (userId: string, thunderId: string): Promise<void> => {
     if (isMembers == 'MEMBER') {
       await Thunder.updateOne({_id: thunderId}, {$pull: {members: myInfo._id}});
 
+      await PersonalChatRoom.findByIdAndDelete(myInfo._id);
+
       await User.findByIdAndUpdate(userId, {
         $pull: {thunderRecords: thunderId},
       });

--- a/src/services/thunder/ThunderService.ts
+++ b/src/services/thunder/ThunderService.ts
@@ -43,7 +43,11 @@ const createThunder = async (
 
     for (var i = 0; i < user.length; i++) {
       if (user[i].isAlarms[0]) {
-        pushHandler.pushAlarmToUser(user[i]._id.toString());
+        pushHandler.pushAlarmToUser(
+          user[i]._id.toString(),
+          '번개방이 생성됐어요~! 확인해 볼까요?',
+          '',
+        );
       }
     }
 
@@ -58,7 +62,7 @@ const findThunderAll = async (
   userId: string,
 ): Promise<ThunderResponseDto[]> => {
   try {
-    const currentTime = new Date(); //현재 날짜 및 시간
+    const currentTime = new Date().getTime() + 3600000 * 9; //현재 날짜 및 시간
     const thunderlist = await Thunder.find({
       deadline: {$gt: currentTime},
     }).sort({createdAt: 'desc'});
@@ -78,6 +82,7 @@ const findThunderAll = async (
             const user = await User.findById(member);
 
             thunderMembers.push({
+              userId: user!._id,
               name: user!.name as string,
               introduction: user!.introduction as string,
               hashtags: user!.hashtags as [string],
@@ -138,7 +143,7 @@ const findThunderByHashtag = async (
   userId: string,
 ): Promise<ThunderResponseDto[]> => {
   try {
-    const currentTime = new Date(); //현재 날짜 및 시간
+    const currentTime = new Date().getTime() + 3600000 * 9; //현재 날짜 및 시간
     const thunderlist = await Thunder.find({
       hashtags: hashtag,
       deadline: {$gt: currentTime},
@@ -158,6 +163,7 @@ const findThunderByHashtag = async (
             const user = await User.findById(member);
 
             thunderMembers.push({
+              userId: user!._id,
               name: user!.name,
               introduction: user!.introduction,
               hashtags: user!.hashtags,

--- a/src/services/thunder/ThunderService.ts
+++ b/src/services/thunder/ThunderService.ts
@@ -91,8 +91,7 @@ const findThunderAll = async (
       thunderlist.map(async (thunder: any) => {
         const idList = []; // User._id[]
 
-        for (let member of thunder.member) {
-          //PersonalRoomInfo.id
+        for (let member of thunder.members) {
           const info = await PersonalChatRoom.findById(member); //PersonalRoomInfo
           idList.push(info.userId);
         }
@@ -179,7 +178,7 @@ const findThunderByHashtag = async (
       thunderlist.map(async (thunder: any) => {
         const idList = []; // User._id[]
 
-        for (let member of thunder.member) {
+        for (let member of thunder.members) {
           const info = await PersonalChatRoom.findById(member);
           idList.push(info.userId);
         }

--- a/src/services/user/UserService.ts
+++ b/src/services/user/UserService.ts
@@ -12,6 +12,8 @@ import ThunderServiceUtils from '../../services/thunder/ThunderServiceUtils';
 import message from '../../modules/message';
 import Thunder from '../../models/Thunder';
 import PersonalChatRoom from '../../models/PersonalChatRoom';
+import mongoose from 'mongoose';
+import ThunderRecord from '../../models/ThunderRecord';
 
 const findUserById = async (userId: string) => {
   try {
@@ -143,8 +145,9 @@ const findUserThunderRecord = async (
     const thunderRecord: UserThunderRecordResponseDto[] = [];
 
     await Promise.all(
-      user!.thunderRecords.map(async (record: any) => {
-        const thunder = await Thunder.findById(record);
+      user!.thunderRecords.map(async (id: mongoose.Schema.Types.ObjectId) => {
+        const record = await ThunderRecord.findById(id);
+        const thunder = await Thunder.findById(record.thunderId);
 
         thunderRecord.push({
           thunderId: thunder!._id,

--- a/src/services/user/UserService.ts
+++ b/src/services/user/UserService.ts
@@ -69,9 +69,12 @@ const deleteUser = async (userId: string) => {
       thunderList.push(record.thunderId);
     }
 
+    const currentTime = new Date().getDate() + 3600000 * 9;
+
     const thunderNotToDelete = await Thunder.find({
       $in: thunderList,
       'members.0': {$in: idList},
+      deadline: {$gt: currentTime},
     });
 
     if (thunderNotToDelete) {

--- a/src/services/user/UserService.ts
+++ b/src/services/user/UserService.ts
@@ -59,7 +59,6 @@ const deleteUser = async (userId: string) => {
 
     for (let info of personalRoomInfo) {
       idList.push(info._id);
-      await PersonalChatRoom.findByIdAndDelete(info);
     }
     console.log(idList);
 
@@ -71,6 +70,10 @@ const deleteUser = async (userId: string) => {
 
     for (let thunder of thunderToDelete) {
       await Thunder.findByIdAndDelete(thunder._id);
+    }
+
+    for (let id of idList) {
+      await PersonalChatRoom.findByIdAndDelete(id);
     }
 
     await User.findByIdAndDelete(userId);

--- a/src/services/user/UserService.ts
+++ b/src/services/user/UserService.ts
@@ -152,6 +152,7 @@ const findUserThunderRecord = async (
         thunderRecord.push({
           thunderId: thunder!._id,
           title: thunder!.title,
+          hashtags: thunder!.hashtags,
           deadline: await ThunderServiceUtils.dateFormat(thunder!.deadline),
         });
       }),

--- a/src/services/user/UserService.ts
+++ b/src/services/user/UserService.ts
@@ -62,21 +62,18 @@ const deleteUser = async (userId: string) => {
     }
     console.log(idList);
 
-    const thunderToDelete = await Thunder.find({
+    const thunderNotToDelete = await Thunder.find({
       'members.0': {$in: idList},
     });
 
-    console.log(thunderToDelete);
-
-    for (let thunder of thunderToDelete) {
-      await Thunder.findByIdAndDelete(thunder._id);
+    if (thunderNotToDelete) {
+      throw errorGenerator({
+        msg: message.USER_CANNOT_DELETE,
+        statusCode: statusCode.FORBIDDEN,
+      });
+    } else {
+      await User.findByIdAndDelete(userId);
     }
-
-    for (let id of idList) {
-      await PersonalChatRoom.findByIdAndDelete(id);
-    }
-
-    await User.findByIdAndDelete(userId);
   } catch (error) {
     console.log(error);
     throw error;


### PR DESCRIPTION

## 관련 이슈 번호 🔎

- [HAN-127](https://koreatech-hanbun.atlassian.net/browse/HAN-127?atlOrigin=eyJpIjoiN2Q2OGFkNzViNjY1NDk4ZGFhOWUwNTI2N2VhNzQyMjMiLCJwIjoiaiJ9)

<br>

## 주요 변경 사항 🔑

- 1. DELETE
- DELETE 시 유저 정보 삭제뿐만 아니라 해당 유저 명의로 되어 있는 PersonalRoomInfo 삭제. PersonalRoomInfo를 이용하여 해당 info 가 member의 0번째 인덱스 내용인(== 해당 유저가 호스트인) 번개 글이 있으면 계정 삭제 불가.

<br>

## 하고싶은 말 📢

-

<br>

## 관련 스크린샷 (선택) 📷

-

<br>

## 참고자료 📚

-

<br>


[HAN-127]: https://koreatech-hanbun.atlassian.net/browse/HAN-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ